### PR TITLE
Prefer existing $PATH over $SNAP/bin

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,7 +14,7 @@ apps:
   protoc:
     command: bin/protoc
     environment:
-      PATH: $SNAP/bin:$PATH
+      PATH: $PATH:$SNAP/bin
       LD_LIBRARY_PATH: $SNAP_LIBRARY_PATH:$SNAP/lib:$LD_LIBRARY_PATH
   protoc-gen-go:
     command: bin/protoc-gen-go


### PR DESCRIPTION
Fixes #3.

I'm not 100% sure if this is how snap environment flags work - can't say I've ever written one, but this seems fairly sensible.